### PR TITLE
Correct line 329 so it doesn't loose list of items

### DIFF
--- a/MicrosoftStoreServicesSample/Controllers/CollectionsController.cs
+++ b/MicrosoftStoreServicesSample/Controllers/CollectionsController.cs
@@ -326,7 +326,7 @@ namespace MicrosoftStoreServicesSample.Controllers
 
                         //  Append the results to our collections list before possibly doing
                         //  another request to get the rest.
-                        usersCollection.Concat(collectionsResponse.Items);
+                        usersCollection = usersCollection.Concat( collectionsResponse.Items ).ToList();
 
                     } while (collectionsResponse.ContinuationToken != null);
                 }


### PR DESCRIPTION
In CollectionController on line 329 you have
`usersCollection.Concat( collectionsResponse.Items )` this however does not ADD the items to the existing collection Instead it creates a new IEnumerable, which it promptly drops on the floor